### PR TITLE
char driver: change entry under /dev

### DIFF
--- a/driver/usb_char_driver/usb_rgb.c
+++ b/driver/usb_char_driver/usb_rgb.c
@@ -120,7 +120,7 @@ static struct file_operations led_fops = {
 };
 
 static struct usb_class_driver led_class = {
-	.name       = "rgb_led%d",
+	.name       = "rgb_led",
 	.fops       = &led_fops,      /* Connect with /dev/rgb_led%d */
 	.minor_base = LED_MINOR_BASE, /* Minor number start */
 };


### PR DESCRIPTION
Previously entry was named rgb_led%d, with %d being a number of device.
as in our case we don't plane to use more than a device at time
rgb_led is a good enough and simpler naming.